### PR TITLE
Small error in smooth-nd.cpp in my linux box

### DIFF
--- a/src/smooth-nd.cpp
+++ b/src/smooth-nd.cpp
@@ -2,6 +2,7 @@
 #include <Rcpp.h>
 #include "group.hpp"
 #include "Summary2d.hpp"
+#include <memory>
 using namespace Rcpp;
 
 std::auto_ptr<Summary2d> createSummary(std::string type) {
@@ -58,7 +59,7 @@ NumericVector smooth_nd_1(const NumericMatrix& grid_in,
   // efficient running sum
 
   for(int j = 0; j < n_out; ++j) {
-    std::auto_ptr<Summary2d> summary = createSummary(type);
+      std::auto_ptr<Summary2d> summary = std::auto_ptr<Summary2d>(createSummary(type));
     for (int i = 0; i < n_in; ++i) {
       // Check that all variables (apart from var) are equal
       bool equiv = true;


### PR DESCRIPTION
Hi,

I really want to thank you for this package. I read the preprint of the paper and it looks promising. 

When I tried to install it on my Debian unstable (sid)  I get this message error : 

``` r
smooth-nd.cpp:7:1: error: 'auto_ptr' in namespace 'std' does not name a type
smooth-nd.cpp: In function 'Rcpp::NumericVector smooth_nd_1(const NumericMatrix&, const NumericVector&, const NumericVector&, const NumericMatrix&, int, double, std::string)':
smooth-nd.cpp:61:5: error: 'auto_ptr' is not a member of 'std'
smooth-nd.cpp:61:28: error: expected primary-expression before '>' token
smooth-nd.cpp:61:30: error: 'summary' was not declared in this scope
smooth-nd.cpp:61:58: error: 'createSummary' was not declared in this scope
```

Therefore I modified this file (smooth-nd.cpp). 
Check the diff to see the two modifications I added to make it work for me.
Just hope that it doesn't break any code.
Also if this error is related to my hardware, config or something else just let me know

Cheers

--------------- Linux Info ---------------------------
Linux dickoa 3.2.0-4-amd64 #1 SMP Debian 3.2.41-2 x86_64 GNU/Linux

---------------- gcc version ------------------------
gcc (Debian 4.7.2-5) 4.7.2

--------------- R session Info ----------------------
R version 3.0.0 RC (2013-03-30 r62448)
Platform: x86_64-pc-linux-gnu (64-bit)

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C  
 [3] LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8  
 [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8  
 [7] LC_PAPER=C                 LC_NAME=C  
 [9] LC_ADDRESS=C               LC_TELEPHONE=C  
[11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       

attached base packages:
[1] utils base 
